### PR TITLE
#31 Defect with returned playlist

### DIFF
--- a/src/spotify_interface.py
+++ b/src/spotify_interface.py
@@ -92,7 +92,7 @@ class spotify_interface:
     def search_tracks(self, terms, limit):
         headers = {"Authorization" : "Bearer {0}".format(self._token)}
         payload = {"q" : "", "type" : "track", "limit" : str(limit)}
-        space = "+" # used to separate search terms
+        space = " " # used to separate search terms
         for t in terms:
             if payload["q"] == "":
                 payload["q"] = t


### PR DESCRIPTION
The playlist returned by our Spotify interface implementation slightly differs from the playlist returned by the Spotify client.

This was resolved by changing the separator between search terms from '+' to ' ' (a single space). Previously, the '+' was acting as an AND operator, whereas it was expected to behave as an OR operator, which the single space represents.